### PR TITLE
feat(auth): Implement HttpOnly cookie flow and user endpoint

### DIFF
--- a/src/main/java/com/pwdk/grocereach/Auth/Application/Implements/AuthServiceImpl.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Application/Implements/AuthServiceImpl.java
@@ -33,7 +33,7 @@ public class AuthServiceImpl implements AuthService {
     private final AuthenticationManager authenticationManager; // For login
     private final TokenGeneratorService tokenGeneratorService;
     private final JwtDecoder refreshTokenDecoder;
-    private final UserService userService;// For login
+    private final UserService userService;
 
     @Override
     public User register(RegisterRequest request) {

--- a/src/main/java/com/pwdk/grocereach/Auth/Infrastructure/Securities/SecurityConfig.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Infrastructure/Securities/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.pwdk.grocereach.Auth.Infrastructure.Securities;
 
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import com.pwdk.grocereach.Auth.Application.Services.UserService;
+import jakarta.servlet.http.Cookie;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -18,9 +19,15 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import javax.crypto.spec.SecretKeySpec;
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -51,13 +58,46 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())))
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.decoder(jwtDecoder()))
+                        .bearerTokenResolver(bearerTokenResolver()) // <-- ADD THIS
+                )
                 .build();
+    }
+
+    @Bean
+    public BearerTokenResolver bearerTokenResolver() {
+        return request -> {
+            Cookie[] cookies = request.getCookies();
+            if (cookies != null) {
+                for (Cookie cookie : cookies) {
+                    if ("accessToken".equals(cookie.getName())) {
+                        return cookie.getValue();
+                    }
+                }
+            }
+            return new DefaultBearerTokenResolver().resolve(request);
+        };
+    }
+
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/src/main/java/com/pwdk/grocereach/Auth/Presentation/Controllers/AuthController.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Presentation/Controllers/AuthController.java
@@ -2,8 +2,11 @@ package com.pwdk.grocereach.Auth.Presentation.Controllers;
 
 import com.pwdk.grocereach.Auth.Application.Services.AuthService;
 import com.pwdk.grocereach.Auth.Presentation.Dto.*;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +28,6 @@ public class AuthController {
         }
     }
 
-
     @PostMapping("/verify")
     public ResponseEntity<?> verify(@RequestBody VerifyRequest request) {
         try {
@@ -35,33 +37,79 @@ public class AuthController {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
+
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) { // No longer need HttpServletResponse here
         try {
-            LoginResponse response = authService.login(request);
-            return ResponseEntity.ok(response);
-        } catch (IllegalStateException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+            LoginResponse loginResponse = authService.login(request);
+
+            ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", loginResponse.getAccessToken().getValue())
+                    .httpOnly(true)
+                    .secure(false)
+                    .path("/")
+                    .maxAge(15 * 60) // 15 minutes
+                    .sameSite("Lax")
+                    .build();
+
+            ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", loginResponse.getRefreshToken().getValue())
+                    .httpOnly(true)
+                    .secure(false)
+                    .path("/")
+                    .maxAge(30 * 24 * 60 * 60) // 30 days
+                    .sameSite("Lax")
+                    .build();
+
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                    .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                    .body("Login successful.");
+
         } catch (AuthenticationException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid email or password.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
         }
     }
+
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshToken(@RequestBody RefreshTokenRequest request) {
         try {
-            LoginResponse response = authService.refreshToken(request);
-            return ResponseEntity.ok(response);
+            LoginResponse loginResponse = authService.refreshToken(request);
+
+            ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", loginResponse.getAccessToken().getValue())
+                    .httpOnly(true).secure(false).path("/").maxAge(15 * 60).sameSite("Lax").build();
+
+            ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", loginResponse.getRefreshToken().getValue())
+                    .httpOnly(true).secure(false).path("/").maxAge(30 * 24 * 60 * 60).sameSite("Lax").build();
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                    .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                    .body("Token refreshed successfully.");
+
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid refresh token.");
         }
     }
+
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@RequestBody RefreshTokenRequest request) {
-        try {
+    public ResponseEntity<?> logout(@RequestBody(required = false) RefreshTokenRequest request) { // Make body optional
+        // Invalidate the token on the backend
+        if (request != null && request.getRefreshToken() != null) {
             authService.logout(request);
-            return ResponseEntity.ok("User logged out successfully.");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred during logout.");
         }
+
+        // Create expired cookies to clear them from the browser
+        ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", "")
+                .httpOnly(true).secure(false).path("/").maxAge(0).sameSite("Lax").build();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true).secure(false).path("/").maxAge(0).sameSite("Lax").build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body("User logged out successfully.");
     }
 }

--- a/src/main/java/com/pwdk/grocereach/Auth/Presentation/Controllers/UserController.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Presentation/Controllers/UserController.java
@@ -1,0 +1,30 @@
+package com.pwdk.grocereach.Auth.Presentation.Controllers;
+
+import com.pwdk.grocereach.Auth.Application.Services.UserService;
+import com.pwdk.grocereach.Auth.Domain.Entities.User;
+import com.pwdk.grocereach.Auth.Infrastructure.Securities.CustomUserDetails;
+import com.pwdk.grocereach.Auth.Presentation.Dto.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    // We need the UserService to look up the user
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getCurrentUser(Authentication authentication) {
+        String email = authentication.getName();
+        UserDetails userDetails = userService.loadUserByUsername(email);
+        User user = ((CustomUserDetails) userDetails).getUser();
+        return ResponseEntity.ok(new UserResponse(user));
+    }
+}

--- a/src/main/java/com/pwdk/grocereach/Auth/Presentation/Dto/UserResponse.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Presentation/Dto/UserResponse.java
@@ -1,0 +1,22 @@
+package com.pwdk.grocereach.Auth.Presentation.Dto;
+
+import com.pwdk.grocereach.Auth.Domain.Entities.User;
+import com.pwdk.grocereach.Auth.Domain.Enums.UserRole;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class UserResponse {
+    private UUID id;
+    private String email;
+    private String fullName;
+    private UserRole role;
+
+    public UserResponse(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.fullName = user.getFullName();
+        this.role = user.getRole();
+    }
+}


### PR DESCRIPTION
Finalizes the authentication system by refactoring the token handling to use secure HttpOnly cookies and adding a protected endpoint for the frontend to retrieve the current user's data.

HttpOnly Cookie Implementation:

The /login, /refresh, and /logout endpoints in AuthController have been updated to set and clear tokens in HttpOnly cookies, preventing client-side script access and enhancing security against XSS attacks.

SecurityConfig now includes a custom BearerTokenResolver to extract the accessToken from cookies, allowing the security filter chain to validate requests correctly.

A robust CORS configuration has been added to permit credentialed requests from the frontend origin (http://localhost:3000).

Current User Endpoint (/me):

A new UserController has been created with a protected /api/users/me endpoint.

This allows the frontend to securely verify a user's session on page load and fetch their data to populate the UI state.

A UserResponse DTO was implemented to ensure no sensitive information (like the password hash) is ever sent to the client.

Bug Fixes:

Resolved a ClassCastException in the UserController by correctly looking up the user via the UserService instead of casting the JWT principal.

Improved error handling in the AuthController to ensure clean, simple error messages are always sent to the frontend, preventing React from crashing on failed login attempts.