### PR TITLE
feat(auth): Add resend verification and enhance token security

### DIFF
--- a/src/main/java/com/pwdk/grocereach/Auth/Application/Implements/EmailServiceImpl.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Application/Implements/EmailServiceImpl.java
@@ -1,35 +1,59 @@
 package com.pwdk.grocereach.Auth.Application.Implements;
 
 import com.pwdk.grocereach.Auth.Application.Services.EmailService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.mail.SimpleMailMessage;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
 
     private final JavaMailSender mailSender;
 
+    @Autowired
+    public EmailServiceImpl(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
     @Override
     public void sendVerificationEmail(String to, String token) {
-        String subject = "Grocereach Email Verification";
-        String verificationLink = "http://localhost:3000/verify?token=" + token;
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8"); 
 
-        String body = "Hello,\n\n"
-                + "Please verify your Grocereach account by clicking the link below:\n"
-                + verificationLink + "\n\n"
-                + "This link will expire in 1 hour.\n\n"
-                + "Regards,\n"
-                + "Grocereach Team";
+            helper.setTo(to);
+            helper.setSubject("Verify Your Grocereach Account");
+            String verificationUrl = "http://localhost:3000/verify/" + token;
+            String htmlMsg = "<body style='font-family: Arial, sans-serif; line-height: 1.6; color: #333;'>"
+                    + "<div style='max-width: 600px; margin: 20px auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;'>"
+                    + "<h2 style='color: #059669;'>Welcome to Grocereach!</h2>"
+                    + "<p>Thank you for registering. Please click the button below to verify your email address and set your password.</p>"
+                    + "<p>This link is valid for 1 hour.</p>"
+                    + "<a href='" + verificationUrl + "' "
+                    + "style='"
+                    + "display: inline-block; "
+                    + "padding: 12px 24px; "
+                    + "margin: 20px 0; "
+                    + "font-size: 16px; "
+                    + "font-weight: bold; "
+                    + "color: #ffffff; "
+                    + "background-color: #10B981; "
+                    + "text-decoration: none; "
+                    + "border-radius: 5px;"
+                    + "'>"
+                    + "Verify Account"
+                    + "</a>"
+                    + "<p>If you did not create an account, no further action is required.</p>"
+                    + "</div>"
+                    + "</body>";
 
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(to);
-        message.setSubject(subject);
-        message.setText(body);
-        message.setFrom("noreply@grocereach.com");
+            helper.setText(htmlMsg, true);
 
-        mailSender.send(message);
+            mailSender.send(message);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to send verification email", e);
+        }
     }
 }

--- a/src/main/java/com/pwdk/grocereach/Auth/Application/Services/AuthService.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Application/Services/AuthService.java
@@ -8,8 +8,9 @@ public interface AuthService {
     User register(RegisterRequest request);
     void verifyAccount(VerifyRequest request);
     LoginResponse login(LoginRequest request);
-    LoginResponse refreshToken(RefreshTokenRequest request);
-    void logout(RefreshTokenRequest request);
+    LoginResponse refreshToken(String refreshToken);
+    void logout(String refreshToken);
+    void resendVerification(String email);
 
 }
 

--- a/src/main/java/com/pwdk/grocereach/Auth/Domain/Entities/User.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Domain/Entities/User.java
@@ -70,7 +70,7 @@ public class User {
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
-    @Column(name = "password",nullable = true)
+    @Column(name = "password",nullable = false)
     private String password;
 }
 

--- a/src/main/java/com/pwdk/grocereach/Auth/Infrastructure/Securities/CookieUtil.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Infrastructure/Securities/CookieUtil.java
@@ -1,0 +1,19 @@
+package com.pwdk.grocereach.Auth.Infrastructure.Securities;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+public class CookieUtil {
+    public static Optional<String> getCookieValue(HttpServletRequest request, String cookieName) {
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals(cookieName)) {
+                return Optional.of(cookie.getValue());
+            }
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
This commit introduces several key improvements to the authentication backend, focusing on enhancing security, adding user-friendly recovery flows, and increasing robustness.

Resend Verification Email:

Implemented a new endpoint (POST /api/auth/resend-verification) that allows unverified users to request a new verification link.

The service logic ensures that this feature cannot be used for accounts that are already verified, returning an appropriate error message.

Enhanced Refresh Token Security (Mentor Feedback):

Refactored the /refresh and /logout endpoints to read the refreshToken directly from its secure, HttpOnly cookie instead of the request body. This reduces the token's exposure.

The refreshToken cookie's path is now restricted to /api/auth, following the Principle of Least Privilege. The browser will only send this sensitive token to authentication-related endpoints.

Improved Logout Flow:

The /logout endpoint is now a protected route that identifies the user via their accessToken. It invalidates the session by deleting the refreshToken from the Redis whitelist and sends back expired cookies to clear them from the browser.

Bug Fixes & Refinements:

Resolved a ClassCastException in the /api/users/me endpoint by correctly looking up the user via the UserService from the JWT's subject.

Improved error handling in the AuthController to catch AuthenticationException specifically, ensuring clean error messages are sent to the frontend.

Updated the EmailServiceImpl to send a professional, HTML-formatted email with a clickable button instead of a plain text link.

Refactored the user registration process to set a secure, random password hash for unverified users, allowing the database column to remain non-nullable.