### PR TITLE
 Implement secure password reset flow

### DIFF
--- a/src/main/java/com/pwdk/grocereach/Auth/Application/Implements/EmailServiceImpl.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Application/Implements/EmailServiceImpl.java
@@ -56,4 +56,42 @@ public class EmailServiceImpl implements EmailService {
             throw new RuntimeException("Failed to send verification email", e);
         }
     }
-}
+    @Override
+    public void sendPasswordResetEmail(String to, String token) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(to);
+            helper.setSubject("Reset Your Grocereach Password");
+
+            String resetUrl = "http://localhost:3000/reset-password/" + token; // Using clean URL
+            String htmlMsg = "<body style='font-family: Arial, sans-serif; line-height: 1.6; color: #333;'>"
+                    + "<div style='max-width: 600px; margin: 20px auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;'>"
+                    + "<h2 style='color: #059669;'>Password Reset Request</h2>"
+                    + "<p>You are receiving this email because a password reset request was made for your account.</p>"
+                    + "<p>Please click the button below to set a new password. This link is valid for 1 hour.</p>"
+                    + "<a href='" + resetUrl + "' "
+                    + "style='"
+                    + "display: inline-block; "
+                    + "padding: 12px 24px; "
+                    + "margin: 20px 0; "
+                    + "font-size: 16px; "
+                    + "font-weight: bold; "
+                    + "color: #ffffff; "
+                    + "background-color: #10B981; "
+                    + "text-decoration: none; "
+                    + "border-radius: 5px;"
+                    + "'>"
+                    + "Reset Password"
+                    + "</a>"
+                    + "<p>If you did not request a password reset, please ignore this email.</p>"
+                    + "</div>"
+                    + "</body>";
+
+            helper.setText(htmlMsg, true);
+            mailSender.send(message);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to send password reset email", e);
+        }
+    }}

--- a/src/main/java/com/pwdk/grocereach/Auth/Application/Services/AuthService.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Application/Services/AuthService.java
@@ -9,8 +9,10 @@ public interface AuthService {
     void verifyAccount(VerifyRequest request);
     LoginResponse login(LoginRequest request);
     LoginResponse refreshToken(String refreshToken);
-    void logout(String refreshToken);
+    void logout(String userId);
     void resendVerification(String email);
+    void requestPasswordReset(String email);
+    void confirmPasswordReset(String token, String newPassword);
 
 }
 

--- a/src/main/java/com/pwdk/grocereach/Auth/Application/Services/EmailService.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Application/Services/EmailService.java
@@ -2,5 +2,7 @@ package com.pwdk.grocereach.Auth.Application.Services;
 
 public interface EmailService {
     void sendVerificationEmail(String to, String token);
+    void sendPasswordResetEmail(String to, String token);
+
 }
 

--- a/src/main/java/com/pwdk/grocereach/Auth/Application/Services/UserService.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Application/Services/UserService.java
@@ -4,11 +4,12 @@ import com.pwdk.grocereach.Auth.Presentation.Dto.UserResponse;
 import com.pwdk.grocereach.User.Presentation.Dto.UpdateProfileRequest;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
 public interface UserService extends UserDetailsService {
-    UserResponse updateUserProfile(String email, UpdateProfileRequest request);
+    UserResponse updateUserProfile(String userId, UpdateProfileRequest request, MultipartFile profileImage);
     UserDetails loadUserById(UUID id);
 
 }

--- a/src/main/java/com/pwdk/grocereach/Auth/Infrastructure/Securities/SecurityConfig.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Infrastructure/Securities/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .jwt(jwt -> jwt.decoder(jwtDecoder()))
-                        .bearerTokenResolver(bearerTokenResolver()) // <-- ADD THIS
+                        .bearerTokenResolver(bearerTokenResolver())
                 )
                 .build();
     }

--- a/src/main/java/com/pwdk/grocereach/Auth/Presentation/Controllers/AuthController.java
+++ b/src/main/java/com/pwdk/grocereach/Auth/Presentation/Controllers/AuthController.java
@@ -4,12 +4,12 @@ import com.pwdk.grocereach.Auth.Application.Services.AuthService;
 import com.pwdk.grocereach.Auth.Infrastructure.Securities.CookieUtil;
 import com.pwdk.grocereach.Auth.Presentation.Dto.*;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,54 +21,21 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
-
-    @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestBody RegisterRequest request) {
-        try {
-            authService.register(request);
-            return ResponseEntity.ok("Registration successful. Please check your email to verify your account.");
-        } catch (IllegalStateException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
-    }
-
-    @PostMapping("/verify")
-    public ResponseEntity<?> verify(@RequestBody VerifyRequest request) {
-        try {
-            authService.verifyAccount(request);
-            return ResponseEntity.ok("Account verified successfully. You can now log in.");
-        } catch (IllegalStateException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
-    }
-
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest request) { // No longer need HttpServletResponse here
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
         try {
             LoginResponse loginResponse = authService.login(request);
 
             ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", loginResponse.getAccessToken().getValue())
-                    .httpOnly(true)
-                    .secure(false)
-                    .path("/")
-                    .maxAge(15 * 60) // 15 minutes
-                    .sameSite("Lax")
-                    .build();
+                    .httpOnly(true).secure(false).path("/").maxAge(15 * 60).sameSite("Lax").build();
 
             ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", loginResponse.getRefreshToken().getValue())
-                    .httpOnly(true)
-                    .secure(false)
-                    .path("/api/auth")
-                    .maxAge(30 * 24 * 60 * 60) // 30 days
-                    .sameSite("Lax")
-                    .build();
-
+                    .httpOnly(true).secure(false).path("/api/auth").maxAge(30 * 24 * 60 * 60).sameSite("Lax").build();
 
             return ResponseEntity.ok()
                     .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                     .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
                     .body("Login successful.");
-
         } catch (AuthenticationException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid email or password.");
         } catch (Exception e) {
@@ -94,15 +61,15 @@ public class AuthController {
                     .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                     .header(HttpHeaders.SET_COOKIE, newRefreshTokenCookie.toString())
                     .body("Token refreshed successfully.");
-
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid refresh token.");
         }
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(HttpServletRequest request) {
-        CookieUtil.getCookieValue(request, "refreshToken").ifPresent(authService::logout);
+    public ResponseEntity<?> logout(Authentication authentication) {
+        String email = authentication.getName();
+        authService.logout(email);
 
         ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", "").httpOnly(true).secure(false).path("/").maxAge(0).sameSite("Lax").build();
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", "").httpOnly(true).secure(false).path("/api/auth").maxAge(0).sameSite("Lax").build();
@@ -112,12 +79,36 @@ public class AuthController {
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
                 .body("User logged out successfully.");
     }
+
     @PostMapping("/resend-verification")
     public ResponseEntity<?> resendVerification(@RequestBody Map<String, String> payload) {
         try {
             authService.resendVerification(payload.get("email"));
             return ResponseEntity.ok("A new verification email has been sent. Please check your inbox.");
         } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+    @PostMapping("/forgot-password")
+    public ResponseEntity<?> forgotPassword(@RequestBody Map<String, String> payload) {
+        try {
+            authService.requestPasswordReset(payload.get("email"));
+            // Always return a generic success message to prevent email enumeration attacks
+            return ResponseEntity.ok("If an account with that email exists, a password reset link has been sent.");
+        } catch (Exception e) {
+            // Even if an error occurs (like user not found), send a generic success message.
+            return ResponseEntity.ok("If an account with that email exists, a password reset link has been sent.");
+        }
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<?> resetPassword(@RequestBody Map<String, String> payload) {
+        try {
+            String token = payload.get("token");
+            String newPassword = payload.get("newPassword");
+            authService.confirmPasswordReset(token, newPassword);
+            return ResponseEntity.ok("Your password has been successfully reset. You can now log in.");
+        } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }


### PR DESCRIPTION
Builds the complete backend functionality for a secure, token-based password reset process. This allows verified users who have forgotten their password to regain access to their account.

Request Reset Endpoint (/forgot-password):

A new public endpoint is created for users to initiate a password reset by submitting their email address.

The service logic ensures that a reset can only be requested for an existing, verified account.

For security, the endpoint always returns a generic success message to prevent attackers from using it to discover which emails are registered in the system (email enumeration).

Token Management with Redis:

A unique, single-use password reset token is generated and stored in Redis with a 1-hour expiration time, ensuring the reset link is temporary.

Email Service Integration:

The EmailService has been updated with a new method to send a professional, HTML-formatted email containing the secure reset link.

Confirm Reset Endpoint (/reset-password):

A new public endpoint allows the user to submit the token from the email along with their new password.

The service validates the token against the Redis store, hashes the new password, updates the user's record in the database, and immediately invalidates the token by deleting it from Redis.