### PR TITLE
Refactor Address entity and fix primary address logic

### DIFF
--- a/src/main/java/com/pwdk/grocereach/User/Domain/Entities/Address.java
+++ b/src/main/java/com/pwdk/grocereach/User/Domain/Entities/Address.java
@@ -49,8 +49,7 @@ public class Address {
     private String postalCode;
 
     @Column(name = "is_primary", nullable = false)
-    @Builder.Default
-    private boolean isPrimary = false;
+    private boolean isPrimary ;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @Builder.Default

--- a/src/main/java/com/pwdk/grocereach/User/Infrastructure/Repositories/AddressRepository.java
+++ b/src/main/java/com/pwdk/grocereach/User/Infrastructure/Repositories/AddressRepository.java
@@ -3,6 +3,9 @@ package com.pwdk.grocereach.User.Infrastructure.Repositories; // Or your correct
 import com.pwdk.grocereach.Auth.Domain.Entities.User;
 import com.pwdk.grocereach.User.Domain.Entities.Address;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,5 +17,7 @@ public interface AddressRepository extends JpaRepository<Address, UUID> {
     List<Address> findByUser(User user);
     Optional<Address> findByIdAndUser(UUID id, User user);
     Optional<Address> findByUserAndIsPrimaryTrue(User user);
-
+    @Modifying
+    @Query("UPDATE Address a SET a.isPrimary = false WHERE a.user = :user AND a.isPrimary = true")
+    void unsetAllPrimaryAddressesForUser(@Param("user") User user);
 }


### PR DESCRIPTION
This commit introduces a complete overhaul of the user address management feature on the backend, moving to a more robust, normalized database structure and fixing critical bugs related to the primary address functionality.

1. Database Schema Refactor (Normalization) The Address entity has been updated to store foreign key relationships (province_id, city_id) to the Province and City entities, instead of storing their names as simple strings.

This improves data integrity, reduces redundancy, and makes the database schema more efficient and maintainable.

The AddressRequest DTO has been updated to accept provinceId and cityId.

The AddressResponse DTO is now smarter, correctly joining and returning the names of the associated province and city.

The AddressServiceImpl has been refactored to handle these new entity relationships, fetching the Province and City objects before saving an address.

2. Primary Address Logic Fix Fixed a critical transactional bug where the isPrimary flag was not being correctly updated when a new primary address was set.

Implemented a new, more reliable method in the AddressRepository using a @Modifying query (unsetAllPrimaryAddressesForUser). This performs a direct, atomic UPDATE on the database, preventing the race conditions that occurred with the previous save() based logic.

3. New Business Rule: First Address is Primary The createAddress method in AddressServiceImpl has been enhanced. It now automatically checks if a user has any existing addresses.

If it is the user's first address,